### PR TITLE
Add fingerprint authentication support to lockscreen

### DIFF
--- a/hyprlock.conf
+++ b/hyprlock.conf
@@ -89,14 +89,31 @@ input-field {
     outer_color = $lite_orange     
     font_color = $text
     check_color = $accent          
-    fail_color = rgba(243, 139, 168, 1.0) 
-    rounding = -1 
+    fail_color = rgba(243, 139, 168, 1.0)
+    fade_on_empty = false
+    rounding = -1
     position = 0, -210
     halign = center
     valign = center
 }
 
-# 5. SPOTIFY (Waveform Animation)
+auth {
+    fingerprint:enabled = true
+}
+
+# 5. FINGERPRINT ICON (only shown if enrolled)
+label {
+    monitor =
+    text = cmd[update:1000] ~/.config/hypr/scripts/fingerprint-icon.sh
+    color = $lite_orange
+    font_size = 32
+    font_family = $font
+    position = 0, -155
+    halign = center
+    valign = center
+}
+
+# 6. SPOTIFY (Waveform Animation)
 label {
     monitor =
     text = cmd[update:1000] echo "$(~/.config/hypr/scripts/spotify.sh)"

--- a/scripts/fingerprint-icon.sh
+++ b/scripts/fingerprint-icon.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if fprintd-list "$USER" 2>/dev/null | grep -q "finger"; then
+    echo "󰈷"
+else
+    echo ""
+fi


### PR DESCRIPTION
## Summary
- Enable fingerprint (fprintd) authentication in hyprlock
- Add a fingerprint icon label that only displays when the user has enrolled fingerprints
- Add `scripts/fingerprint-icon.sh` helper script for fingerprint enrollment detection

## Test plan
- [ ] Verify fingerprint unlock works on a system with fprintd and enrolled fingerprints
- [ ] Verify the fingerprint icon appears only when fingerprints are enrolled
- [ ] Verify lockscreen still works normally on systems without fprintd

🤖 Generated with [Claude Code](https://claude.com/claude-code)